### PR TITLE
Fix "Invalid prospect email address"

### DIFF
--- a/pardot/resource.py
+++ b/pardot/resource.py
@@ -211,6 +211,8 @@ class Resource(object):
             self.login()
 
         payload['api_key'] = self.api_key
+        # Need to drop email so it won't confuse Pardot.
+        payload.pop('email')
 
         # run the request and retry once if the request fails with a
         # login error (Pardot API error code '1')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'hammock==0.2.4',
         'pprintpp==0.3.0',
-        'six==1.10.0',
+        'six>=1.10.0',
     ],
     test_suite='nose.collector',
     tests_require=['nose', 'responses'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'hammock==0.2.4',
         'pprintpp==0.3.0',
-        'six~=1.11.0',
+        'six>=1.11.0',
     ],
     test_suite='nose.collector',
     tests_require=['nose', 'responses'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'hammock==0.2.4',
         'pprintpp==0.3.0',
-        'six>=1.10.0',
+        'six~=1.11.0',
     ],
     test_suite='nose.collector',
     tests_require=['nose', 'responses'],


### PR DESCRIPTION
After getting api_key, email can be dropped from the payload in the future POST requests. In some cases reported in  #1 , it seems to confuse the API. 